### PR TITLE
rp is not PHONY, it is a real binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /admin.kubeconfig
 /env
 /id_rsa
+/rp

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-rp:
+build:
 	go build -ldflags "-X main.gitCommit=$(shell git rev-parse --short HEAD)$(shell [[ $$(git status --porcelain) = "" ]] || echo -dirty)" ./cmd/rp
 
 clean:
@@ -14,4 +14,4 @@ image:
 test: generate
 	go test ./...
 
-.PHONY: clean generate image rp test
+.PHONY: clean generate image build test


### PR DESCRIPTION
This currently works, but is confusing.
We have a default target of "rp" it produces a real binary "rp", but then mark the target as ".PHONY"
which normally means that the target is not actually produced.
I am just changing the target name to "build" to make this less confusing and adding "rp" to .gitigone as well.