### PR TITLE
Go 1.13 linting

### DIFF
--- a/pkg/deploy/nsg.go
+++ b/pkg/deploy/nsg.go
@@ -16,7 +16,7 @@ func GenerateNSGTemplate() error {
 		Schema:         "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
 		ContentVersion: "1.0.0.0",
 		Resources: []*arm.Resource{
-			&arm.Resource{
+			{
 				Resource: &msi.Identity{
 					Name:     to.StringPtr("rp-identity"),
 					Location: to.StringPtr("[resourceGroup().location]"),
@@ -24,7 +24,7 @@ func GenerateNSGTemplate() error {
 				},
 				APIVersion: apiVersions["msi"],
 			},
-			&arm.Resource{
+			{
 				Resource: &network.SecurityGroup{
 					SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
 						SecurityRules: &[]network.SecurityRule{


### PR DESCRIPTION
Changes in how code is structured causes test failures. Move to go1.13 is mandatory.