### PR TITLE
Add coverage

### DIFF
--- a/.github/workflows/pull_request-test.yaml
+++ b/.github/workflows/pull_request-test.yaml
@@ -23,3 +23,11 @@ jobs:
         set -x
         make test
         [[ -z "$(git status -s)" ]]
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.txt
+        flags: unittests
+        name: codecov-umbrella
+        fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /id_rsa
 /rp
 /secrets
+/coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -61,4 +61,7 @@ test: generate
 	go vet ./...
 	go test ./... -coverprofile=coverage.txt -covermode=atomic
 
+view-test: test
+	go tool cover -html=coverage.txt
+
 .PHONY: rp clean client generate image secrets secrets-update test

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,6 @@ test: generate
 	@sha256sum --quiet -c .sha256sum || (echo error: client library is stale, please run make client; exit 1)
 
 	go vet ./...
-	go test ./...
+	go test ./... -coverprofile=coverage.txt -covermode=atomic
 
 .PHONY: rp clean client generate image secrets secrets-update test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # github.com/jim-minter/rp
 
+[![codec=ov](https://codecov.io/gh/jim-minter/ro/branch/master/graph/badge.svg)](https://codecov.io/gh/jim-minter/rp)"
+
 ## Install
 
 1. Install the following:


### PR DESCRIPTION
Add test coverage?

@jim-minter  wdyt if we add this and just use github workflow for it without complicating our lives with adding this to CI? To work on your repo it is missing secret in your repo with CODE_COV token from `openshift-azure-robot`

And "wrong result issue" too 

+ `make view-test` allows to open code coverage in browser to see "where I should go and write tests next" 