### PR TITLE
add rg and name clash validation

### DIFF
--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -54,6 +54,7 @@ var (
 	CloudErrorCodeInvalidLinkedVNet                  = "InvalidLinkedVNet"
 	CloudErrorCodeNotFound                           = "NotFound"
 	CloudErrorCodeForbidden                          = "Forbidden"
+	CloudErrorCodeConflict                           = "Conflict"
 	CloudErrorCodeInvalidSubscriptionState           = "CloudErrorCodeInvalidSubscriptionState"
 	CloudErrorCodeInvalidServicePrincipalCredentials = "InvalidServicePrincipalCredentials"
 	CloudErrorCodeInvalidResourceProviderPermissions = "InvalidResourceProviderPermissions"

--- a/pkg/frontend/middleware/validate.go
+++ b/pkg/frontend/middleware/validate.go
@@ -57,6 +57,11 @@ func Validate(h http.Handler) http.Handler {
 				api.WriteError(w, http.StatusNotFound, api.CloudErrorCodeResourceNotFound, "", "The Resource '%s/%s/%s' under resource group '%s' was not found.", vars["resourceProviderNamespace"], vars["resourceType"], vars["resourceName"], vars["resourceGroupName"])
 				return
 			}
+
+			if vars["resourceName"] == vars["resourceGroupName"] {
+				api.WriteError(w, http.StatusConflict, api.CloudErrorCodeConflict, "", "The Resource name '%s' and resource group name '%s' must be unique.", vars["resourceName"], vars["resourceGroupName"])
+				return
+			}
 		}
 
 		queries, err := route.GetQueriesTemplates()


### PR DESCRIPTION
If resourceGroup exists and it is the same name as a cluster - the provider fails. 

We should fail early.
